### PR TITLE
docs: translate outline title and Addon Navs

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -87,11 +87,11 @@ const Theme: (DefaultTheme.NavItemWithLink | DefaultTheme.NavItemChildren)[] = [
 
 const Addon: DefaultTheme.NavItemWithLink[] = [
   {
-    text: 'Use Addon',
+    text: '使用扩展插件',
     link: '/addons/use',
   },
   {
-    text: 'Write an Addon',
+    text: '编写扩展插件',
     link: '/addons/write-an-addon',
   },
 ]

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -280,6 +280,10 @@ export default defineConfig({
       text: '改进翻译',
     },
 
+    outline: {
+      label: '本页目录'
+    },
+
     search: {
       provider: 'local',
     },


### PR DESCRIPTION
调整了 VitePress 的 outline title 为中文
NavItem 中 Use Addon 和 Write an Addon 翻译遗漏