### PR TITLE
docs: fix incorrect link quotes

### DIFF
--- a/features/index.md
+++ b/features/index.md
@@ -44,7 +44,7 @@ function removeTag(tag: string) {
 
 这是 Slidev 提供的所有特性的列表。每个特性都可以独立使用，并且是可选的。
 
-您还可以阅读 <LinkInline link=“guide/index”/> 分类学习这些特性。
+您还可以阅读 <LinkInline link="guide/index"/> 分类学习这些特性。
 
 <div flex items-center mt-6 gap-6>
   <div


### PR DESCRIPTION
<!--
我们计划在近期合并全新版英文文档（https://github.com/slidevjs/slidev/pull/1736），请确认对于中文文档的修改不会被新版文档覆盖，非常感谢！
-->

- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[主仓库](https://github.com/slidevjs/slidev))

**问题描述**:

修正文档中错误的引号导致 `/features` 404 的问题

