### PR TITLE
fix: 修复快速上手文档底部Next page指向错误的问题

### DIFF
--- a/.vitepress/pages.ts
+++ b/.vitepress/pages.ts
@@ -5,7 +5,7 @@ export const Guides = [
   },
   {
     text: '快速上手',
-    link: '/guide/index',
+    link: '/guide/',
   },
   {
     text: '语法',


### PR DESCRIPTION
- [x] 我对翻译内容的改动不包含基于英文原版的扩展、删减或演绎 (如有，请移步至[主仓库](https://github.com/slidevjs/slidev))

**问题描述**: 原《快速上手》这页文档的底部，Next page指向《为什么选 Slidev》是错误的。修改后正确根据配置指向下一页《语法》。
