### PR TITLE
Update global-context.md

### DIFF
--- a/guide/global-context.md
+++ b/guide/global-context.md
@@ -53,7 +53,7 @@ onSlideLeave(() => { /* ... */ })
 
 ::: warning
 
-当使用 `useSlideContext` 时，将禁用自动注入 `$slidev`。你需要手动将 `$slidev` 对象传递给 `useSlideContext` 函数。
+当使用 `useSlideContext` 时，将禁用自动注入 `$slidev`。你需要手动从 `useSlideContext` 函数里获取 `$slidev`。
 
 :::
 


### PR DESCRIPTION
**问题描述**:

原文是: _When the useSlideContext composable is used in a file, the automatic injection of $slidev will be disabled. You need to manually get the $slidev object to the useSlideContext function._

首先我英语不太好，但我确定这里想表达的意思应该不是把 `$slidev` 当参数传递给 `useSlideContext`。而是从 `useSlideContext` 获取 `$slidev`。所以这个原文是不是也需要修改成 `get ... from` 更好。虽然 `get ... to` 也能理解。